### PR TITLE
So as griffin_lim.py to find *.h5 for eval

### DIFF
--- a/crank/bin/griffin_lim.py
+++ b/crank/bin/griffin_lim.py
@@ -45,9 +45,9 @@ def main():
         logging.info("{}: {}".format(k, v))
 
     # find h5 files
-    feats_files = sorted(list(Path(args.rootdir).glob("*.h5")))
+    feats_files = sorted(list(Path(args.rootdir).glob("**/*.h5")))
     feats = {
-        Path(args.outdir) / filename.stem + ".wav": read_feature(filename, "feats")
+        Path(args.outdir) / (filename.stem + ".wav"): read_feature(filename, "feats")
         for filename in feats_files
     }
 


### PR DESCRIPTION
--voc GL did not work because griffin_lim.py could not find *.h5 for eval.
A quick hack for Griffin-Lim to work.